### PR TITLE
Fix Time Slept metric: minutes always two digits 

### DIFF
--- a/src/c/rect.c
+++ b/src/c/rect.c
@@ -325,7 +325,7 @@ void draw_secondary_info(FContext *fctx, uint_least8_t font_size, uint_least8_t 
          snprintf(SECONDARY_INFO, sizeof(SECONDARY_INFO), "CR  %d", health_calories_rest);
          break;
        case SECONDARY_INFO_TIME_SLEPT:
-         snprintf(SECONDARY_INFO, sizeof(SECONDARY_INFO), "SLP %d%c%d", (int)(health_time_slept / 3600), FLAG_HOURS_MINUTES_SEPARATOR, (int)(health_time_slept % 3600 / 60));
+         snprintf(SECONDARY_INFO, sizeof(SECONDARY_INFO), "SLP %d%c%02d", (int)(health_time_slept / 3600), FLAG_HOURS_MINUTES_SEPARATOR, (int)(health_time_slept % 3600 / 60));
          break;
        case SECONDARY_INFO_CALORIES_ACTIVE:
          snprintf(SECONDARY_INFO, sizeof(SECONDARY_INFO), "CA  %d",health_calories_active);

--- a/src/c/round.c
+++ b/src/c/round.c
@@ -330,7 +330,7 @@ void draw_secondary_info(FContext *fctx, uint_least8_t position, uint_least8_t s
          snprintf(SECONDARY_INFO, sizeof(SECONDARY_INFO), "CR  %d", health_calories_rest);
          break;
        case SECONDARY_INFO_TIME_SLEPT:
-         snprintf(SECONDARY_INFO, sizeof(SECONDARY_INFO), "SLP %d%c%d", (int)(health_time_slept / 3600), FLAG_HOURS_MINUTES_SEPARATOR, (int)(health_time_slept % 3600 / 60));
+         snprintf(SECONDARY_INFO, sizeof(SECONDARY_INFO), "SLP %d%c%02d", (int)(health_time_slept / 3600), FLAG_HOURS_MINUTES_SEPARATOR, (int)(health_time_slept % 3600 / 60));
          break;
        case SECONDARY_INFO_CALORIES_ACTIVE:
          snprintf(SECONDARY_INFO, sizeof(SECONDARY_INFO), "CA  %d",health_calories_active);


### PR DESCRIPTION
Well, maybe you merged #4 prematurely. `0:0` is not a timestamp I can accept, now it's always two digits for the minutes ( `0:00`).